### PR TITLE
fix: variable in node_groups.tf

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -86,7 +86,7 @@ resource "yandex_kubernetes_node_group" "node_groups" {
 
   allocation_policy {
     dynamic "location" {
-      for_each = [var.node_groups_locations[0]]
+      for_each = [local.node_groups_locations[0]]
 
       content {
         zone = location.value.zone


### PR DESCRIPTION
When using var.node_groups_locations terraform plan generate error:

```
on .terraform/modules/clusters/node_groups.tf line 89, in resource "yandex_kubernetes_node_group" "node_groups":
│   89:       for_each = [var.node_groups_locations[0]]
```

seems there is mistake in variable naming. node_groups_locations depend on masters_groups_locations and it's the local variable, isn't it?