### PR TITLE
Fix network, k8s version, runs-on

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   linters:
     name: 'Terraform Linters'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           download_external_modules: false
   semver:
     name: 'Set code version tag'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs:

--- a/examples/clusters/variables.tf
+++ b/examples/clusters/variables.tf
@@ -110,7 +110,7 @@ variable "clusters" {
 
       type = "zonal"
 
-      master_version      = "1.27"
+      master_version      = "1.30"
       master_public_ip    = true
       master_auto_upgrade = false
       master_maintenance_windows = [

--- a/examples/clusters/variables.tf
+++ b/examples/clusters/variables.tf
@@ -110,7 +110,7 @@ variable "clusters" {
 
       type = "zonal"
 
-      master_version      = "1.30"
+      master_version      = "1.29"
       master_public_ip    = true
       master_auto_upgrade = false
       master_maintenance_windows = [

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,3 +1,5 @@
+data "yandex_client_config" "client" {}
+
 module "iam_accounts" {
   source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-iam.git//modules/iam-account?ref=v1.0.0"
 
@@ -19,10 +21,28 @@ module "iam_accounts" {
 
 }
 
+module "network" {
+  source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-vpc.git?ref=v1.0.0"
+
+  folder_id = data.yandex_client_config.client.folder_id
+
+  blank_name = "redis-vpc-nat-gateway"
+  labels = {
+    repo = "terraform-yacloud-modules/terraform-yandex-vpc"
+  }
+
+  azs = ["ru-central1-a", "ru-central1-b", "ru-central1-d"]
+
+  private_subnets = [["10.10.0.0/24"], ["10.11.0.0/24"], ["10.12.0.0/24"]]
+
+  create_vpc         = true
+  create_nat_gateway = true
+}
+
 module "kube" {
   source = "../../"
 
-  network_id = "xxxx"
+  network_id  = module.network.vpc_id
 
   name = "test-kubernetes"
 
@@ -32,7 +52,7 @@ module "kube" {
   master_locations = [
     {
       zone      = "ru-central1-a"
-      subnet_id = "xxxx"
+      subnet_id = module.network.private_subnets_ids[0]
     }
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "kms_provider_key_id" {
 variable "master_version" {
   description = "Version of K8S that will be used for master"
   type        = string
-  default     = "1.27"
+  default     = "1.30"
 }
 
 variable "master_public_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "kms_provider_key_id" {
 variable "master_version" {
   description = "Version of K8S that will be used for master"
   type        = string
-  default     = "1.30"
+  default     = "1.29"
 }
 
 variable "master_public_ip" {


### PR DESCRIPTION
Fix:
```
│ Error: error while requesting API to create Kubernetes cluster: client-request-id = 651d14e1-c1e6-414b-8c2c-0fb51f6af392 client-trace-id = 2b83cc03-3518-4e5a-9223-7234bd5b7e62 rpc error: code = InvalidArgument desc = Validation error:
│ network_id: network "xxxx" not found
```
and
```
│ Error: error while requesting API to create Kubernetes cluster: client-request-id = 672a4f0d-8a24-48ec-801f-8a21ee07e299 client-trace-id = 420e3bb5-fa3d-4377-bdfc-23e88f98040c rpc error: code = FailedPrecondition desc = Precondition failure:
│ version is deprecated for cluster: version 1.27 is deprecated for this release channel
```
and
```
│ Error: error while requesting API to create Kubernetes cluster: client-request-id = cbab04e3-f256-4b9f-8fa5-82f25200ce09 client-trace-id = ee46c74b-c48f-4fb9-b677-cec58d32aa19 rpc error: code = FailedPrecondition desc = Precondition failure:
│ version is deprecated for cluster: version 1.28 is deprecated for this release channel
```