### PR TITLE
Обновление примера конфигурации и версии Kubernetes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "kms_provider_key_id" {
 variable "master_version" {
   description = "Version of K8S that will be used for master"
   type        = string
-  default     = "1.29"
+  default     = "1.30"
 }
 
 variable "master_public_ip" {


### PR DESCRIPTION
Добавлен модуль network для автоматического создания VPC и NAT Gateway

Замена хардкодных значений network_id и subnet_id на выходные значения модуля сети

Обновлена версия Kubernetes по умолчанию с 1.29 до 1.30

Добавлено явное указание subnet_ids для node group

Улучшена структура конфигурации для большей гибкости и читаемости