### PR TITLE
fix node_groups

### DIFF
--- a/examples/1master-2nodegroup/main.tf
+++ b/examples/1master-2nodegroup/main.tf
@@ -59,6 +59,7 @@ module "kube" {
 
   node_groups = {
     "fixed-scale" = {
+      subnet_ids = [module.network.private_subnets_ids[0]]
       nat    = true
       cores  = 2
       memory = 4
@@ -68,6 +69,7 @@ module "kube" {
     }
 
     "auto-scale" = {
+      subnet_ids = [module.network.private_subnets_ids[0]]
       nat    = true
       cores  = 2
       memory = 8

--- a/examples/1master-2nodegroup/main.tf
+++ b/examples/1master-2nodegroup/main.tf
@@ -60,9 +60,9 @@ module "kube" {
   node_groups = {
     "fixed-scale" = {
       subnet_ids = [module.network.private_subnets_ids[0]]
-      nat    = true
-      cores  = 2
-      memory = 4
+      nat        = true
+      cores      = 2
+      memory     = 4
       fixed_scale = {
         size = 1
       }
@@ -70,9 +70,9 @@ module "kube" {
 
     "auto-scale" = {
       subnet_ids = [module.network.private_subnets_ids[0]]
-      nat    = true
-      cores  = 2
-      memory = 8
+      nat        = true
+      cores      = 2
+      memory     = 8
       auto_scale = {
         min     = 1
         max     = 5

--- a/examples/1master-2nodegroup/outputs.tf
+++ b/examples/1master-2nodegroup/outputs.tf
@@ -1,0 +1,4 @@
+output "get_credentials_command" {
+  description = "Command to get kubeconfig for the cluster"
+  value       = module.kube.get_credentials_command
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "default_ssh_key_prv" {
   description = "Default node groups that is attached to all node groups"
   value       = var.generate_default_ssh_key ? tls_private_key.default_ssh_key[0].private_key_openssh : null
 }
+
+output "get_credentials_command" {
+  description = "Command to get kubeconfig for the cluster"
+  value       = "yc managed-kubernetes cluster get-credentials --id ${yandex_kubernetes_cluster.main.id} --external"
+}


### PR DESCRIPTION
fix:
```
You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
╷
│ Error: Missing required argument
│ 
│   with module.kube.yandex_kubernetes_node_group.node_groups["auto-scale"],
│   on ../../node_groups.tf line 58, in resource "yandex_kubernetes_node_group" "node_groups":
│   58:       subnet_ids = try(each.value["subnet_ids"], each.value["zones"] != null ? [
│   59:         for zone in each.value["zones"] : lookup(
│   60:           { for item in local.node_groups_locations : item.zone => item.subnet_id },
│   61:           zone,
│   62:           null
│   63:         )
│   64:         if lookup({ for item in local.node_groups_locations : item.zone => item.subnet_id }, zone, null) != null
│   65:         ] : [
│   66:         for location in [local.node_groups_locations[0]] : location.subnet_id
│   67:       ])
│ 
│ The argument "instance_template.0.network_interface.0.subnet_ids" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│ 
│   with module.kube.yandex_kubernetes_node_group.node_groups["fixed-scale"],
│   on ../../node_groups.tf line 58, in resource "yandex_kubernetes_node_group" "node_groups":
│   58:       subnet_ids = try(each.value["subnet_ids"], each.value["zones"] != null ? [
│   59:         for zone in each.value["zones"] : lookup(
│   60:           { for item in local.node_groups_locations : item.zone => item.subnet_id },
│   61:           zone,
│   62:           null
│   63:         )
│   64:         if lookup({ for item in local.node_groups_locations : item.zone => item.subnet_id }, zone, null) != null
│   65:         ] : [
│   66:         for location in [local.node_groups_locations[0]] : location.subnet_id
│   67:       ])
│ 
│ The argument "instance_template.0.network_interface.0.subnet_ids" is required, but no definition was found.

```